### PR TITLE
Feature: Shield Ducky Power Up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea/

--- a/src/components/board.css
+++ b/src/components/board.css
@@ -42,14 +42,6 @@
     border: 2px solid grey;
   }
   
-  .jumper {
-    border: 2px dashed blue;
-  }
-  
-  .blocker {
-    border: 2px solid red;
-  }
-  
   .ducky-selection {
     margin-top: 10px;
   }
@@ -59,4 +51,12 @@
     padding: 10px;
     font-size: 16px;
   }
-  
+
+.selected {
+  background-color: yellow; /* Highlight color */
+  border: 2px solid #000;  /* Optional: Add a border to make it more noticeable */
+}
+
+.shielded-piece {
+  border: 2px solid rgb(255, 0, 0);
+}


### PR DESCRIPTION
### Enhancements:

- Displays the current number of discs each player has.

### Additions:
- Shielded pieces have a red border for visual distinction.
- Shielded pieces do not get flipped when surrounded.
- Each player can use a shield only once per game.
- Neighbouring pieces to the shielded piece can still be flipped.
- Once placed, a piece remains unchanged:
     - Shields cannot be removed or replaced.
     - Regular duckies cannot be converted into shields.